### PR TITLE
add runtime output and exit on fail

### DIFF
--- a/src/evolve.jl
+++ b/src/evolve.jl
@@ -29,8 +29,13 @@ function evolve(sim::MultiDomainSimulation)
         if stop_evolve(sim) == true
             break
         end
+        start_runtimer(sim)
         watch_keep_time(sim)
         advance(sim)
+        end_runtimer(sim)
+        if sim.failed == true
+            break
+        end
         write_step(sim)
     end
     finalize_writing(sim)
@@ -230,4 +235,24 @@ end
 function regress_time(sim::SingleDomainSimulation)
     sim.integrator.time = sim.model.time = sim.integrator.prev_time
     sim.integrator.stop -= 1
+end
+
+function start_runtimer(sim::SingleDomainSimulation)
+    sim.integrator.runtime_step = time()
+end
+
+function start_runtimer(sim::MultiDomainSimulation)
+    for subsim ∈ sim.subsims
+        subsim.integrator.runtime_step = time()
+    end
+end
+
+function end_runtimer(sim::SingleDomainSimulation)
+    sim.integrator.runtime_step = time() - sim.integrator.runtime_step
+end
+
+function end_runtimer(sim::MultiDomainSimulation)
+    for subsim ∈ sim.subsims
+        subsim.integrator.runtime_step = time() - subsim.integrator.runtime_step
+    end
 end

--- a/src/time_integrator_def.jl
+++ b/src/time_integrator_def.jl
@@ -6,6 +6,7 @@ mutable struct QuasiStatic <: StaticTimeIntegrator
     initial_time::Float64
     final_time::Float64
     time_step::Float64
+    runtime_step::Float64
     minimum_time_step::Float64
     maximum_time_step::Float64
     decrease_factor::Float64
@@ -24,6 +25,7 @@ mutable struct Newmark <: DynamicTimeIntegrator
     initial_time::Float64
     final_time::Float64
     time_step::Float64
+    runtime_step::Float64
     minimum_time_step::Float64
     maximum_time_step::Float64
     decrease_factor::Float64
@@ -46,6 +48,7 @@ mutable struct CentralDifference <: DynamicTimeIntegrator
     initial_time::Float64
     final_time::Float64
     time_step::Float64
+    runtime_step::Float64
     minimum_time_step::Float64
     maximum_time_step::Float64
     decrease_factor::Float64


### PR DESCRIPTION
Adds `runtime_step` as a global variable in Exodus output. This records the wall clock runtime of each time step, for use in total runtime metrics.

Also, this terminates execution when a simulation has failed. Previously, if a simulation failed the time step outer loop would continue until the set final time, and repeatedly write the system state at failure to the output file. This made it difficult to determine after the fact whether a simulation had failed and wastes disk space. This ultimately does not address the edge case where the simulation fails on the final time step.