### PR TITLE
Fixing make_op_inf_models.py NS/SS names in OpInf script

### DIFF
--- a/examples/ahead/single/cuboid/dynamic-opinf-fom/make_op_inf_models.py
+++ b/examples/ahead/single/cuboid/dynamic-opinf-fom/make_op_inf_models.py
@@ -20,7 +20,7 @@ if __name__ == "__main__":
     displacement_snapshots[free_dofs[:,:]==False] = 0.
     
     #Get sideset snapshots
-    sidesets = ["nsx-","nsy-","nsz-","nsz+"]
+    sidesets = ["nsx--x","nsy--y","nsz--z","nsz+-z"]
     sideset_snapshots = normaopinf.readers.load_sideset_displacement_csv_files(solution_directory=cur_dir,sidesets=sidesets,solution_id=solution_id,skip_files=1)
     
     


### PR DESCRIPTION
The script would not run due to incorrect ns/ss names.  With this fix, it runs.  

@eparish1 : can you please check that this is OK to merge?