### PR TITLE
Moving non-overlapping Schwarz tests out of short set of Norma tests.

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -62,7 +62,7 @@ const indexed_test_files = [
 const all_test_files = [file for (_, file) in indexed_test_files]
 
 # Optional test indices (excluded from quick runs)
-const optional_test_indices = Int[24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40]
+const optional_test_indices = Int[24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41]
 
 # Quick test set (subset of all tests)
 const quick_test_indices = [i for (i, _) in indexed_test_files if i ∉ optional_test_indices]


### PR DESCRIPTION
It is too long.