### PR TITLE
Updated IO to compute stresses

### DIFF
--- a/src/opinf/opinf_io.jl
+++ b/src/opinf/opinf_io.jl
@@ -16,6 +16,7 @@ end
 
 function write_stop_exodus(sim::SingleDomainSimulation, model::RomModel)
     integrator = sim.integrator
+    solver = sim.solver 
     #Re-construct full state
     displacement = integrator.displacement
     velocity = integrator.velocity
@@ -43,6 +44,7 @@ function write_stop_exodus(sim::SingleDomainSimulation, model::RomModel)
             model.fom_model.acceleration[3, i] = model.basis[3, i, :]'acceleration
         end
     end
+    evaluate(model.fom_model,integrator.fom_integrator,solver.fom_solver)
     write_stop_exodus(sim, model.fom_model)
     return nothing
 end


### PR DESCRIPTION
@ikalash Here is a fix so the OpInf model outputs now have stresses.

@lxmota Would you be able to verify that calling "evaluate" on line 606 of model.jl will fill in the model stresses correctly, and that I'm not missing anything? I've verified that the fields are filled in and look reasonable, but I just want to make sure I'm not missing any extra processing that is applied to them.