### PR TITLE
Fix issue #171 (NO-SAM + ROM not working with interface predictor) and enabling stress recovery for ROM

### DIFF
--- a/examples/ahead/nonoverlap/cuboid/dynamic-linear-elastic-fom-fom/cuboid-1.yaml
+++ b/examples/ahead/nonoverlap/cuboid/dynamic-linear-elastic-fom-fom/cuboid-1.yaml
@@ -5,6 +5,7 @@ CSV output interval: 0.01
 CSV write sidesets: true
 model:
   type: solid mechanics
+  stress recovery: consistent
   material:
     blocks:
       fine: hyperelastic

--- a/examples/ahead/nonoverlap/cuboid/dynamic-linear-elastic-fom-fom/cuboid-2.yaml
+++ b/examples/ahead/nonoverlap/cuboid/dynamic-linear-elastic-fom-fom/cuboid-2.yaml
@@ -5,6 +5,7 @@ CSV output interval: 0.01
 CSV write sidesets: true
 model:
   type: solid mechanics
+  stress recovery: consistent
   material:
     blocks:
       coarse: hyperelastic

--- a/examples/ahead/nonoverlap/cuboid/dynamic-linear-elastic-fom-rom/cuboid-1.yaml
+++ b/examples/ahead/nonoverlap/cuboid/dynamic-linear-elastic-fom-rom/cuboid-1.yaml
@@ -4,6 +4,7 @@ output mesh file: cuboid-1.e
 CSV output interval: 0
 model:
   type: solid mechanics
+  stress recovery: consistent
   material:
     blocks:
       fine: hyperelastic

--- a/examples/ahead/nonoverlap/cuboid/dynamic-linear-elastic-fom-rom/cuboid-2.yaml
+++ b/examples/ahead/nonoverlap/cuboid/dynamic-linear-elastic-fom-rom/cuboid-2.yaml
@@ -5,6 +5,7 @@ CSV output interval: 0
 model:
   type: linear opinf rom
   model-file: opinf-operator-2.npz
+  stress recovery: consistent
   material:
     blocks:
       coarse: hyperelastic

--- a/examples/ahead/nonoverlap/cuboid/dynamic-linear-elastic-fom-rom/cuboids.yaml
+++ b/examples/ahead/nonoverlap/cuboid/dynamic-linear-elastic-fom-rom/cuboids.yaml
@@ -11,3 +11,4 @@ relative tolerance: 1.0e-12
 absolute tolerance: 1.0e-08
 relaxation parameter: 0.473
   #relaxation: aitken
+interface predictor: true

--- a/examples/ahead/nonoverlap/cuboid/dynamic-linear-elastic-rom-fom/cuboid-1.yaml
+++ b/examples/ahead/nonoverlap/cuboid/dynamic-linear-elastic-rom-fom/cuboid-1.yaml
@@ -5,6 +5,7 @@ CSV output interval: 0
 model:
   type: linear opinf rom
   model-file: opinf-operator-1.npz
+  stress recovery: consistent
   material:
     blocks:
       fine: hyperelastic

--- a/examples/ahead/nonoverlap/cuboid/dynamic-linear-elastic-rom-fom/cuboid-2.yaml
+++ b/examples/ahead/nonoverlap/cuboid/dynamic-linear-elastic-rom-fom/cuboid-2.yaml
@@ -4,6 +4,7 @@ output mesh file: cuboid-2.e
 CSV output interval: 0
 model:
   type: solid mechanics
+  stress recovery: consistent
   material:
     blocks:
       coarse: hyperelastic

--- a/examples/ahead/nonoverlap/cuboid/dynamic-linear-elastic-rom-fom/cuboids.yaml
+++ b/examples/ahead/nonoverlap/cuboid/dynamic-linear-elastic-rom-fom/cuboids.yaml
@@ -11,3 +11,4 @@ relative tolerance: 1.0e-12
 absolute tolerance: 1.0e-08
   #relaxation parameter: 0.473
 relaxation: aitken
+interface predictor: true

--- a/examples/ahead/nonoverlap/cuboid/dynamic-linear-elastic-rom-rom/cuboid-1.yaml
+++ b/examples/ahead/nonoverlap/cuboid/dynamic-linear-elastic-rom-rom/cuboid-1.yaml
@@ -5,6 +5,7 @@ CSV output interval: 0
 model:
   type: linear opinf rom
   model-file: opinf-operator-1.npz
+  stress recovery: consistent
   material:
     blocks:
       fine: hyperelastic

--- a/examples/ahead/nonoverlap/cuboid/dynamic-linear-elastic-rom-rom/cuboid-2.yaml
+++ b/examples/ahead/nonoverlap/cuboid/dynamic-linear-elastic-rom-rom/cuboid-2.yaml
@@ -5,6 +5,7 @@ CSV output interval: 0
 model:
   type: linear opinf rom
   model-file: opinf-operator-2.npz
+  stress recovery: consistent
   material:
     blocks:
       coarse: hyperelastic

--- a/examples/ahead/nonoverlap/cuboid/dynamic-linear-elastic-rom-rom/cuboids.yaml
+++ b/examples/ahead/nonoverlap/cuboid/dynamic-linear-elastic-rom-rom/cuboids.yaml
@@ -11,3 +11,4 @@ relative tolerance: 1.0e-12
 absolute tolerance: 1.0e-08
 relaxation parameter: 0.473
   #relaxation: aitken
+interface predictor: true

--- a/examples/ahead/nonoverlap/cuboid/dynamic-neohookean-cubic-fom-rom/cuboid-1.yaml
+++ b/examples/ahead/nonoverlap/cuboid/dynamic-neohookean-cubic-fom-rom/cuboid-1.yaml
@@ -4,6 +4,7 @@ output mesh file: cuboid-1.e
 CSV output interval: 0
 model:
   type: solid mechanics
+  stress recovery: consistent
   material:
     blocks:
       fine: hyperelastic

--- a/examples/ahead/nonoverlap/cuboid/dynamic-neohookean-cubic-fom-rom/cuboid-2.yaml
+++ b/examples/ahead/nonoverlap/cuboid/dynamic-neohookean-cubic-fom-rom/cuboid-2.yaml
@@ -5,6 +5,7 @@ CSV output interval: 0
 model:
   type: cubic opinf rom
   model-file: copinf-operator-2.npz
+  stress recovery: consistent
   material:
     blocks:
       coarse: hyperelastic

--- a/examples/ahead/nonoverlap/cuboid/dynamic-neohookean-cubic-rom-fom/cuboid-1.yaml
+++ b/examples/ahead/nonoverlap/cuboid/dynamic-neohookean-cubic-rom-fom/cuboid-1.yaml
@@ -5,6 +5,7 @@ CSV output interval: 0
 model:
   type: cubic opinf rom
   model-file: copinf-operator-1.npz
+  stress recovery: consistent
   material:
     blocks:
       fine: hyperelastic

--- a/examples/ahead/nonoverlap/cuboid/dynamic-neohookean-cubic-rom-fom/cuboid-2.yaml
+++ b/examples/ahead/nonoverlap/cuboid/dynamic-neohookean-cubic-rom-fom/cuboid-2.yaml
@@ -4,6 +4,7 @@ output mesh file: cuboid-2.e
 CSV output interval: 0
 model:
   type: solid mechanics
+  stress recovery: consistent
   material:
     blocks:
       coarse: hyperelastic

--- a/examples/ahead/nonoverlap/cuboid/dynamic-neohookean-cubic-rom-rom/cuboid-1.yaml
+++ b/examples/ahead/nonoverlap/cuboid/dynamic-neohookean-cubic-rom-rom/cuboid-1.yaml
@@ -5,6 +5,7 @@ CSV output interval: 0
 model:
   type: cubic opinf rom
   model-file: copinf-operator-1.npz
+  stress recovery: consistent
   material:
     blocks:
       fine: hyperelastic

--- a/examples/ahead/nonoverlap/cuboid/dynamic-neohookean-cubic-rom-rom/cuboid-2.yaml
+++ b/examples/ahead/nonoverlap/cuboid/dynamic-neohookean-cubic-rom-rom/cuboid-2.yaml
@@ -5,6 +5,7 @@ CSV output interval: 0
 model:
   type: cubic opinf rom
   model-file: copinf-operator-2.npz
+  stress recovery: consistent
   material:
     blocks:
       coarse: hyperelastic

--- a/examples/ahead/nonoverlap/cuboid/dynamic-neohookean-quadratic-fom-rom/cuboid-1.yaml
+++ b/examples/ahead/nonoverlap/cuboid/dynamic-neohookean-quadratic-fom-rom/cuboid-1.yaml
@@ -4,6 +4,7 @@ output mesh file: cuboid-1.e
 CSV output interval: 0
 model:
   type: solid mechanics
+  stress recovery: consistent
   material:
     blocks:
       fine: hyperelastic

--- a/examples/ahead/nonoverlap/cuboid/dynamic-neohookean-quadratic-fom-rom/cuboid-2.yaml
+++ b/examples/ahead/nonoverlap/cuboid/dynamic-neohookean-quadratic-fom-rom/cuboid-2.yaml
@@ -5,6 +5,7 @@ CSV output interval: 0
 model:
   type: quadratic opinf rom
   model-file: qopinf-operator-2.npz
+  stress recovery: consistent
   material:
     blocks:
       coarse: hyperelastic

--- a/examples/ahead/nonoverlap/cuboid/dynamic-neohookean-quadratic-rom-fom/cuboid-1.yaml
+++ b/examples/ahead/nonoverlap/cuboid/dynamic-neohookean-quadratic-rom-fom/cuboid-1.yaml
@@ -5,6 +5,7 @@ CSV output interval: 0
 model:
   type: quadratic opinf rom
   model-file: qopinf-operator-1.npz
+  stress recovery: consistent
   material:
     blocks:
       fine: hyperelastic

--- a/examples/ahead/nonoverlap/cuboid/dynamic-neohookean-quadratic-rom-fom/cuboid-2.yaml
+++ b/examples/ahead/nonoverlap/cuboid/dynamic-neohookean-quadratic-rom-fom/cuboid-2.yaml
@@ -4,6 +4,7 @@ output mesh file: cuboid-2.e
 CSV output interval: 0
 model:
   type: solid mechanics
+  stress recovery: consistent
   material:
     blocks:
       coarse: hyperelastic

--- a/examples/ahead/nonoverlap/cuboid/dynamic-neohookean-quadratic-rom-rom/cuboid-1.yaml
+++ b/examples/ahead/nonoverlap/cuboid/dynamic-neohookean-quadratic-rom-rom/cuboid-1.yaml
@@ -5,6 +5,7 @@ CSV output interval: 0
 model:
   type: quadratic opinf rom
   model-file: qopinf-operator-1.npz
+  stress recovery: consistent
   material:
     blocks:
       fine: hyperelastic

--- a/examples/ahead/nonoverlap/cuboid/dynamic-neohookean-quadratic-rom-rom/cuboid-2.yaml
+++ b/examples/ahead/nonoverlap/cuboid/dynamic-neohookean-quadratic-rom-rom/cuboid-2.yaml
@@ -5,6 +5,7 @@ CSV output interval: 0
 model:
   type: quadratic opinf rom
   model-file: qopinf-operator-2.npz
+  stress recovery: consistent
   material:
     blocks:
       coarse: hyperelastic

--- a/src/io.jl
+++ b/src/io.jl
@@ -43,8 +43,13 @@ function initialize_writing(sim::SingleDomainSimulation)
         num_node_vars += 6
         append!(node_var_names, ["velo_x", "velo_y", "velo_z", "acce_x", "acce_y", "acce_z"])
     end
-    if !(sim.model isa RomModel) && !(sim.model.recovery_data isa NoRecovery)
-        rec = sim.model.recovery_data
+    # For RomModel, stress recovery is performed on the underlying fom_model after
+    # reconstructing the full displacement field.  Use fom_model as the source of
+    # recovery metadata so that the Exodus variable names are registered correctly
+    # regardless of whether the top-level model is a ROM or a FOM.
+    solid_model = sim.model isa RomModel ? sim.model.fom_model : sim.model
+    if !(solid_model.recovery_data isa NoRecovery)
+        rec = solid_model.recovery_data
         if rec isa BothRecovery
             # Both modes active: qualify each name with the projection method.
             num_node_vars += 12
@@ -55,13 +60,13 @@ function initialize_writing(sim::SingleDomainSimulation)
             num_node_vars += 6
             append!(node_var_names, ["sigma_xx_n", "sigma_yy_n", "sigma_zz_n", "sigma_yz_n", "sigma_xz_n", "sigma_xy_n"])
         end
-        if rec isa BothRecovery && size(sim.model.lumped_recovered_internal_variables, 1) > 0
-            iv_names = collect_internal_variable_names(sim.model.materials)
+        if rec isa BothRecovery && size(solid_model.lumped_recovered_internal_variables, 1) > 0
+            iv_names = collect_internal_variable_names(solid_model.materials)
             num_node_vars += 2 * length(iv_names)
             append!(node_var_names, [name * "_cons_n" for name in iv_names])
             append!(node_var_names, [name * "_lump_n" for name in iv_names])
-        elseif !(rec isa BothRecovery) && size(sim.model.recovered_internal_variables, 1) > 0
-            iv_names = collect_internal_variable_names(sim.model.materials)
+        elseif !(rec isa BothRecovery) && size(solid_model.recovered_internal_variables, 1) > 0
+            iv_names = collect_internal_variable_names(solid_model.materials)
             num_node_vars += length(iv_names)
             append!(node_var_names, [name * "_n" for name in iv_names])
         end

--- a/src/simulation.jl
+++ b/src/simulation.jl
@@ -1049,6 +1049,33 @@ function detect_contact(sim::MultiDomainSimulation)
     return nothing
 end
 
+"""
+    get_phys_state_for_predictor(state, subsim) -> Vector{Float64}
+
+For a FOM subdomain, returns `state` unchanged (already a physical DOF vector indexed
+as [3*(node-1)+d] for node index `node` and component d ∈ {1,2,3}).
+
+For a ROM subdomain, `state` holds ROM latent coordinates (length = num_modes).
+This function reconstructs the full physical DOF vector by applying the model basis:
+
+    u_phys[3*(j-1)+d] = basis[d, j, :] ⋅ state    for each node j, component d
+
+Only free DOFs are set; constrained DOFs default to zero. This is safe because
+`extract_interface_state` only ever reads interface nodes, which are always free DOFs.
+"""
+function get_phys_state_for_predictor(state::Vector{Float64}, subsim::Simulation)
+    model = subsim.model
+    model isa RomModel || return state
+    num_nodes = size(model.basis, 2)
+    phys = zeros(3 * num_nodes)
+    @inbounds for j in 1:num_nodes
+        for d in 1:3
+            phys[3 * (j - 1) + d] = model.basis[d, j, :]' * state
+        end
+    end
+    return phys
+end
+
 function extract_interface_state(global_state::Vector{Float64}, bc::SolidMechanicsSchwarzBoundaryCondition)
     n_local = length(bc.global_from_local_map)
     local_mat = Matrix{Float64}(undef, 3, n_local)
@@ -1103,10 +1130,10 @@ function compute_interface_predictor!(sim::MultiDomainSimulation)
                 isempty(controller.prev_stop_disp[dom_k]) && continue
                 isempty(controller.prev_stop_disp[dom_j]) && continue
 
-                u_k = extract_interface_state(controller.stop_disp[dom_k], bc_k)
-                u_k_prev = extract_interface_state(controller.prev_stop_disp[dom_k], bc_k)
-                u_j = extract_interface_state(controller.stop_disp[dom_j], bc_j)
-                u_j_prev = extract_interface_state(controller.prev_stop_disp[dom_j], bc_j)
+                u_k = extract_interface_state(get_phys_state_for_predictor(controller.stop_disp[dom_k], subsim_k), bc_k)
+                u_k_prev = extract_interface_state(get_phys_state_for_predictor(controller.prev_stop_disp[dom_k], subsim_k), bc_k)
+                u_j = extract_interface_state(get_phys_state_for_predictor(controller.stop_disp[dom_j], subsim_j), bc_j)
+                u_j_prev = extract_interface_state(get_phys_state_for_predictor(controller.prev_stop_disp[dom_j], subsim_j), bc_j)
 
                 # Each domain extrapolates its own interface displacement independently.
                 # This correctly handles non-conforming meshes: domain k predicts its own
@@ -1114,8 +1141,11 @@ function compute_interface_predictor!(sim::MultiDomainSimulation)
                 u_k_pred = @. 2 * u_k - u_k_prev
                 u_j_pred = @. 2 * u_j - u_j_prev
 
-                write_interface_state!(pred_disp_k, u_k_pred, bc_k)
-                write_interface_state!(pred_disp_j, u_j_pred, bc_j)
+                # For ROM subdomains, pred_disp is the ROM latent state (not a physical
+                # DOF vector), so write_interface_state! must not be called on it.
+                # The t_n latent state is already a safe predictor for ROM domains.
+                subsim_k.model isa RomModel || write_interface_state!(pred_disp_k, u_k_pred, bc_k)
+                subsim_j.model isa RomModel || write_interface_state!(pred_disp_j, u_j_pred, bc_j)
             else
                 # Dynamic: velocity predictor via perfectly inelastic collision using
                 # the interface mass matrices W (row-sum lumping).
@@ -1128,9 +1158,11 @@ function compute_interface_predictor!(sim::MultiDomainSimulation)
                 m_k = vec(sum(W_k; dims=2))    # (n_k,)
                 m_j = vec(sum(W_j; dims=2))    # (n_j,)
 
-                # Interface velocities at t_n from stop state
-                v_k = extract_interface_state(controller.stop_velo[dom_k], bc_k)  # (3, n_k)
-                v_j = extract_interface_state(controller.stop_velo[dom_j], bc_j)  # (3, n_j)
+                # Interface velocities at t_n from stop state.
+                # For ROM subdomains stop_velo holds latent coordinates; reconstruct
+                # the physical DOF vector first so extract_interface_state can index it.
+                v_k = extract_interface_state(get_phys_state_for_predictor(controller.stop_velo[dom_k], subsim_k), bc_k)
+                v_j = extract_interface_state(get_phys_state_for_predictor(controller.stop_velo[dom_j], subsim_j), bc_j)
 
                 # Project domain j's mass and velocity into domain k's interface space
                 m_j_in_k = P_kj * m_j    # (n_k,)
@@ -1155,8 +1187,8 @@ function compute_interface_predictor!(sim::MultiDomainSimulation)
                 # Displacement predictor: velocity-consistent linear extrapolation
                 # u_pred = u_n + Δt * v_pred  (each domain uses its own u_n as baseline)
                 Δt = controller.time_step
-                u_k = extract_interface_state(controller.stop_disp[dom_k], bc_k)
-                u_j = extract_interface_state(controller.stop_disp[dom_j], bc_j)
+                u_k = extract_interface_state(get_phys_state_for_predictor(controller.stop_disp[dom_k], subsim_k), bc_k)
+                u_j = extract_interface_state(get_phys_state_for_predictor(controller.stop_disp[dom_j], subsim_j), bc_j)
                 u_pred_k = @. u_k + Δt * v_pred_k
                 u_pred_j = @. u_j + Δt * v_pred_j
 
@@ -1164,10 +1196,20 @@ function compute_interface_predictor!(sim::MultiDomainSimulation)
                 # pred_acce_k and pred_acce_j already contain zero-valued stop_acce (from t_n
                 # corrected acceleration); no modification needed here.
 
-                write_interface_state!(pred_disp_k, u_pred_k, bc_k)
-                write_interface_state!(pred_velo_k, v_pred_k, bc_k)
-                write_interface_state!(pred_disp_j, u_pred_j, bc_j)
-                write_interface_state!(pred_velo_j, v_pred_j, bc_j)
+                # For ROM subdomains, pred_disp/pred_velo hold ROM latent coordinates.
+                # Calling write_interface_state! on them with a physical-space matrix
+                # would use FOM node indices that are out of bounds for the latent vector.
+                # Instead, leave ROM predictors as the t_n latent state (a safe fallback):
+                # schwarz.jl copies predictor_disp into coupled_integrator.displacement
+                # and then calls reconstruct_fom_fields!, so latent coordinates are correct.
+                if !(subsim_k.model isa RomModel)
+                    write_interface_state!(pred_disp_k, u_pred_k, bc_k)
+                    write_interface_state!(pred_velo_k, v_pred_k, bc_k)
+                end
+                if !(subsim_j.model isa RomModel)
+                    write_interface_state!(pred_disp_j, u_pred_j, bc_j)
+                    write_interface_state!(pred_velo_j, v_pred_j, bc_j)
+                end
             end
 
             # Force predictor: linear temporal extrapolation f_pred = 2*f_n - f_{n-1}.

--- a/test/schwarz-ahead-nonoverlap-dynamic-cuboid-fom-rom.jl
+++ b/test/schwarz-ahead-nonoverlap-dynamic-cuboid-fom-rom.jl
@@ -6,7 +6,7 @@
 
 using YAML
 
-@testset "Schwarz AHeaD Non-Overlap Dynamic Cuboid HEX8-HEX8 FOM-ROM" begin
+@testset "Schwarz AHeaD Non-Overlap Dynamic Cuboid HEX8-HEX8 FOM-ROM with Interface Predictor" begin
     cp("../examples/ahead/nonoverlap/cuboid/dynamic-linear-elastic-fom-rom/cuboids.yaml", "cuboids.yaml"; force=true)
     cp("../examples/ahead/nonoverlap/cuboid/dynamic-linear-elastic-fom-rom/cuboid-1.yaml", "cuboid-1.yaml"; force=true)
     cp("../examples/ahead/nonoverlap/cuboid/dynamic-linear-elastic-fom-rom/cuboid-2.yaml", "cuboid-2.yaml"; force=true)

--- a/test/schwarz-ahead-nonoverlap-dynamic-cuboid-rom-fom.jl
+++ b/test/schwarz-ahead-nonoverlap-dynamic-cuboid-rom-fom.jl
@@ -6,7 +6,7 @@
 
 using YAML
 
-@testset "Schwarz AHeaD Non-Overlap Dynamic Cuboid HEX8-HEX8 ROM-FOM" begin
+@testset "Schwarz AHeaD Non-Overlap Dynamic Cuboid HEX8-HEX8 ROM-FOM with Interface Predictor" begin
     cp("../examples/ahead/nonoverlap/cuboid/dynamic-linear-elastic-rom-fom/cuboids.yaml", "cuboids.yaml"; force=true)
     cp("../examples/ahead/nonoverlap/cuboid/dynamic-linear-elastic-rom-fom/cuboid-1.yaml", "cuboid-1.yaml"; force=true)
     cp("../examples/ahead/nonoverlap/cuboid/dynamic-linear-elastic-rom-fom/cuboid-2.yaml", "cuboid-2.yaml"; force=true)
@@ -48,11 +48,12 @@ using YAML
     @test min_disp_x_cuboid2 ≈ -0.16666666925334647 atol = 1e-4
     @test min_disp_y_cuboid2 ≈ -0.16666669868308254 atol = 1e-4
     @test max_disp_z_cuboid2 ≈ 1.0  atol = 1e-4
+
     @test avg_stress_cuboid1 ≈
-        [-36687.00807527736 -46232.997458797494 6.666400992148324e8 -8419.997248528967 -7164.372738533243 -10261.760554080925] atol =
+        [-36739.54601441479 -46299.67040618098 6.666400456236401e8 -8432.636700154815 -7175.132200054923 -10277.009381932328] atol =
         1.0e1
     @test avg_stress_cuboid2 ≈
-        [-6176.934934013523 -8107.854416613001 6.666715762204559e8 185.6016556180562 -142.60953492579762 -897.6286004353053] atol =
+        [-6187.346160379238 -8120.747153351782 6.666716001054254e8 182.88843038098796 -145.74516972091425 -898.7271858482828] atol =
         1.0e1
     @test sim.controller.schwarz_iters ≈ [16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16] atol = 0
 end

--- a/test/schwarz-ahead-nonoverlap-dynamic-cuboid-rom-rom.jl
+++ b/test/schwarz-ahead-nonoverlap-dynamic-cuboid-rom-rom.jl
@@ -6,7 +6,7 @@
 
 using YAML
 
-@testset "Schwarz AHeaD Non-Overlap Dynamic Cuboid HEX8-HEX8 ROM-ROM" begin
+@testset "Schwarz AHeaD Non-Overlap Dynamic Cuboid HEX8-HEX8 ROM-ROM with Interface Predictor" begin
     cp("../examples/ahead/nonoverlap/cuboid/dynamic-linear-elastic-rom-rom/cuboids.yaml", "cuboids.yaml"; force=true)
     cp("../examples/ahead/nonoverlap/cuboid/dynamic-linear-elastic-rom-rom/cuboid-1.yaml", "cuboid-1.yaml"; force=true)
     cp("../examples/ahead/nonoverlap/cuboid/dynamic-linear-elastic-rom-rom/cuboid-2.yaml", "cuboid-2.yaml"; force=true)


### PR DESCRIPTION
I discovered 2 bugs involving OpInf: 
- It did not work with the interface predictor.
- It did not work with stress recovery.

The issues have been fixed.  Should resolve #171 . 

@lxmota : please review when you have the chance.