### PR TITLE
Print test numbers when printing runtest.jl results.

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -180,7 +180,9 @@ Norma.norma_log(0, :norma, "BEGIN TESTS")
 @testset verbose = true "Norma.jl Test Suite" begin
     for (i, file) in test_files_to_run
         Norma.norma_log(0, :test, "[$i] Running $file...")
-        include(file)
+        @testset "[$i] $file" begin
+            include(file)
+        end
     end
 end
 


### PR DESCRIPTION
I find it really annoying that only the test name is printed when the runtests.jl output is printed.  Then I have to grep all the files for the test name, and then grep runtests.jl for the name of the file containing the test name.  

This PR makes it way easier if one wishes to run a test individually afterwards by the test number.