### PR TITLE
Write error messages to the .log file

### DIFF
--- a/src/Norma.jl
+++ b/src/Norma.jl
@@ -44,6 +44,11 @@ function run(input_file::String)
     try
         norma_log(0, :norma, "BEGIN SIMULATION")
         return run(create_simulation(input_file))
+    catch e
+        # Catch here, while the log file is still open, so the error lands in
+        # {example_name}.log.  The finally block closes the file afterward.
+        log_run_error(e, catch_backtrace())
+        rethrow()
     finally
         close_log_file()
     end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -160,10 +160,19 @@ function norma_abortf(fmt::AbstractString, args...)
 end
 
 function log_run_error(e::Exception, bt)
-    msg = sprint(showerror, e)
-    norma_log(0, :error, "Run failed with exception: " * msg)
-    bt_str = sprint(Base.show_backtrace, bt)
-    norma_log(0, :error, "Backtrace:" * bt_str)
+    # Emit one norma_log per line so wrap_lines (which split()s on all
+    # whitespace including '\n') doesn't flatten the backtrace's frame-per-line
+    # structure into a single re-wrapped paragraph.  show_backtrace already
+    # prints its own "Stacktrace:" header, so don't add a redundant label.
+    norma_log(0, :error, "Run failed with exception:")
+    for line in split(sprint(showerror, e), '\n')
+        isempty(line) && continue
+        norma_log(0, :error, line)
+    end
+    for line in split(sprint(Base.show_backtrace, bt), '\n')
+        isempty(line) && continue
+        norma_log(0, :error, line)
+    end
     return nothing
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -159,6 +159,14 @@ function norma_abortf(fmt::AbstractString, args...)
     end
 end
 
+function log_run_error(e::Exception, bt)
+    msg = sprint(showerror, e)
+    norma_log(0, :error, "Run failed with exception: " * msg)
+    bt_str = sprint(Base.show_backtrace, bt)
+    norma_log(0, :error, "Backtrace:" * bt_str)
+    return nothing
+end
+
 function log_matrix(level::Int, keyword::Symbol, label::AbstractString, M::AbstractMatrix)
     norma_log(level, keyword, "$label:")
     for i in axes(M, 1)


### PR DESCRIPTION
Before, Norma was not writing error messages to the .log file, only to the screen.  This PR fixes that.