### PR TITLE
Introduce unrestricted size field smoothing reference

### DIFF
--- a/src/model.jl
+++ b/src/model.jl
@@ -336,11 +336,15 @@ function create_smooth_reference(
             h = avg_edge_length_tet_h(u, v, w)
         elseif smooth_reference == "max"
             h = max(avg_edge_length_tet_h(u, v, w), equal_volume_tet_h(u, v, w))
-        elseif smooth_reference == "size field"
+        elseif smooth_reference == "size field restricted"
             # Target edge length from the user-defined size field at the element
             # reference centroid, combined with the volume criterion (max) to
             # anchor the reference size and avoid sliver pathologies.
             h = max(size_field_tet_h(size_field, element_ref_pos, time), equal_volume_tet_h(u, v, w))
+        elseif smooth_reference == "size field"
+            # Target edge length from the user-defined size field at the element
+            # reference centroid
+            h = size_field_tet_h(size_field, element_ref_pos, time)
         else
             norma_abort("Unknown type of mesh smoothing reference : $smooth_reference")
         end

--- a/test/smoothing.jl
+++ b/test/smoothing.jl
@@ -142,6 +142,38 @@ end
     @test_throws Exception Norma.create_smooth_reference("size field", Norma.TETRA4, reg_tet_coords, bad, 0.0)
 end
 
+    big = Norma.create_size_field("size field restricted", "5.0")
+    ref_big = Norma.create_smooth_reference("size field", Norma.TETRA4, reg_tet_coords, big, 0.0)
+    for e in tet_edges(ref_big)
+        @test e ≈ 5.0 atol = 1.0e-12
+    end
+
+    # A tiny constant size field is dominated by the volume criterion (max), so
+    # the reference matches the equal-volume reference instead.
+    tiny = Norma.create_size_field("size field restricted", "1.0e-6")
+    ref_tiny = Norma.create_smooth_reference("size field restricted", Norma.TETRA4, reg_tet_coords, tiny, 0.0)
+    ref_vol = Norma.create_smooth_reference("equal volume", Norma.TETRA4, reg_tet_coords)
+    @test norm(ref_tiny[:, 1] - ref_tiny[:, 2]) ≈ norm(ref_vol[:, 1] - ref_vol[:, 2]) atol = 1.0e-12
+
+    # A spatially varying field is evaluated at the element reference centroid.
+    sfx = Norma.create_size_field("size field restricted", "10.0*x")
+    for shift in (1.0, 2.5, 4.0)
+        coords = reg_tet_coords .+ [shift; 0.0; 0.0]
+        centroid_x = sum(coords[1, :]) / 4
+        ref = Norma.create_smooth_reference("size field restricted", Norma.TETRA4, coords, sfx, 0.0)
+        for e in tet_edges(ref)
+            @test e ≈ 10.0 * centroid_x atol = 1.0e-10
+        end
+    end
+
+    # A time-varying field uses the supplied time argument.
+    sft = Norma.create_size_field("size field restricted", "2.0 + t")
+    for time in (0.0, 1.0, 3.0)
+        ref = Norma.create_smooth_reference("size field restricted", Norma.TETRA4, reg_tet_coords, sft, time)
+        @test norm(ref[:, 1] - ref[:, 2]) ≈ (2.0 + time) atol = 1.0e-12
+    end
+
+
 base_params = Dict{String,Any}(
     "type" => "single",
     "model" => Dict{String,Any}(


### PR DESCRIPTION
Introduce unrestricted size field smoothing reference as (size field). Rename current restricted size field smooth reference to (size field restricted). When supplying a size field that is smaller than the current size of an element, the previous implementation return the size of the element instead of the size that was being prescribed. This resulted in no contribution from the volumetric component in all of the constitutive models. When plotting the energy, there appears to be a large dip, as only the deviatoric part was contributing something. Removing this restriction now reflects this with a greater energy than before.

A small demo is performed where a cube is smoothed with the current size of all the elements. Afterwards, the size field is changed such that it linearly varies across the x axis, where on one end the size is half of the current size, and the other end remains the current size.

From the restricted size field smoothing reference:

<img width="3000" height="1800" alt="image (2)" src="https://github.com/user-attachments/assets/106bc40a-6ba7-4929-b859-06f254bd41c4" />


From the unrestricted size field smoothing reference: 
<img width="3000" height="1800" alt="image (3)" src="https://github.com/user-attachments/assets/ed3ec367-927d-42c3-b456-da2ad59f7459" />

The energy now shows a contribution from elements that are larger than the target size. 